### PR TITLE
Fix Alpine version detection to verify netboot files exist

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 set -e
-VERSION=$(curl -sL http://dl-cdn.alpinelinux.org/alpine/ | awk -F'(href="|/">)' '/href/ {print $2}' |grep -Po "v\d+.*" | sort -rV | head -n1 | sed 's/^v//')
-# make sure the return has a sane version
-while [[ "${VERSION}" =~ ^[0-9]{1}.[0-9] ]]; do
-  echo "${VERSION}"
-  exit 0
+# obtain latest releases having netboot available
+VERSION=$(curl -sL http://dl-cdn.alpinelinux.org/alpine/ | awk -F'(href="|/">)' '/href/ {print $2}' | grep -Po "v\d+.*" | sort -rV | head -n 3 | sed 's/^v//')
+# make sure the return has a sane version and netboot is at least available for x64
+for this_version in $VERSION; do
+    unset status_code
+    status_code=$(curl --output /dev/null --silent --write-out "%{http_code}" "http://dl-cdn.alpinelinux.org/alpine/v${this_version}/releases/x86_64/netboot/vmlinuz-lts")
+    if [ x"${status_code}" == x"200" ]; then
+        echo "${this_version}"
+        exit 0
+    else
+        :
+    fi
 done
 exit 1

--- a/version.sh
+++ b/version.sh
@@ -4,13 +4,12 @@ set -e
 VERSION=$(curl -sL http://dl-cdn.alpinelinux.org/alpine/ | awk -F'(href="|/">)' '/href/ {print $2}' | grep -Po "v\d+.*" | sort -rV | head -n 3 | sed 's/^v//')
 # make sure the return has a sane version and netboot is at least available for x64
 for this_version in $VERSION; do
-    unset status_code
+
     status_code=$(curl --output /dev/null --silent --write-out "%{http_code}" "http://dl-cdn.alpinelinux.org/alpine/v${this_version}/releases/x86_64/netboot/vmlinuz-lts")
-    if [ x"${status_code}" == x"200" ]; then
+    if [ "$status_code" = "200" ]; then
         echo "${this_version}"
         exit 0
-    else
-        :
+
     fi
 done
 exit 1


### PR DESCRIPTION
Check for HTTP 200 on vmlinuz-lts before accepting a version, preventing 404 errors from pre-release directories. Iterate through top 3 versions to find first with working netboot assets.

Fixes premature version bump to v3.23 which has no release files yet.